### PR TITLE
Update build scripts to use new docker registry

### DIFF
--- a/server/build.bat
+++ b/server/build.bat
@@ -1,5 +1,5 @@
-docker build -t geoguide-server:latest .
+docker build -t geoguide.azurecr.io/server:latest .
 docker stop server
 docker rm server
 docker start MongoDB
-docker run --name server -p 3000:3000 --network geo_guide --env-file ./.env -d geoguide-server:latest
+docker run --name server -p 3000:3000 --network geo_guide --env-file ./.env -d geoguide.azurecr.io/server:latest

--- a/server/build.sh
+++ b/server/build.sh
@@ -1,5 +1,5 @@
-docker build -t geoguide-server:latest .
+docker build -t geoguide.azurecr.io/server:latest .
 docker stop server
 docker rm server
 docker start MongoDB
-docker run --name server -p 3000:3000 --network geo_guide --env-file ./.env -d geoguide-server:latest
+docker run --name server -p 3000:3000 --network geo_guide --env-file ./.env -d geoguide.azurecr.io/server:latest


### PR DESCRIPTION
I have changed the name for the docker image in the build scripts so that we can easily push to the registry